### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 bleed-baidu-white
 ==================
 
-###更新说明：
+### 更新说明：
 
 *	2014-03-22：新增两种链接类型	
 *   2014-03-16：加入文件大小属性
 *   2013-11-22：开始应对百度最新变化，支持百度短地址，如：[http://pan.baidu.com/s/1mgK7dQ4](http://pan.baidu.com/s/1mgK7dQ4)
 *	2013-08-22：开始支持[yun.baidu.com](http://yun.baidu.com)链接
 
-###榨干百度网盘计划
+### 榨干百度网盘计划
 
 如果你自己写的App内有离线数据需要下载，但又像我一样一穷二白买不起类似又拍云的云存储服务。
 
 那就跟我一起来榨干百度网盘吧！
 
-###计划步骤：
+### 计划步骤：
 
 1	将目标文件上传到百度网盘，并且分享之
 
@@ -27,10 +27,10 @@ bleed-baidu-white
 5	开始下载吧！
 
 
-###部署
+### 部署
 系统已经部署到 [http://daimajia.duapp.com](http://daimajia.duapp.com)，并且长期提供稳定服务，欢迎大家使用。
 
-###用法
+### 用法
 
 Step1：获取百度网盘分享链接
 
@@ -42,7 +42,7 @@ Step2: 构造请求链接
 
 Step3:发送请求，获取含真实地址的JSON数据。
 
-###链接类型
+### 链接类型
 
 <http://pan.baidu.com/s/1bn7tXHd> [尝试](http://daimajia.duapp.com/baidu/?url=http://pan.baidu.com/s/1bn7tXHd)
 
@@ -50,9 +50,9 @@ Step3:发送请求，获取含真实地址的JSON数据。
 
 <http://pan.baidu.com/share/link?shareid=1938327270&uk=2855000475&fid=2233423979> [尝试](http://daimajia.duapp.com/baidu/?url=http://pan.baidu.com/share/link?shareid=1938327270&uk=2855000475&fid=2233423979)
 
-###还在犹豫什么？投入使用吧！
+### 还在犹豫什么？投入使用吧！
 
-###关于我：
+### 关于我：
 我是个学生，酷爱开发，擅长Android、php、python、nodejs、web，欢迎各种实习扫射:  [daimajia#gmail.com](mailto:daimajia@gmail.com)
 
 *	[西北大学](http://zh.wikipedia.org/wiki/%E8%A5%BF%E5%8C%97%E5%A4%A7%E5%AD%A6_\(%E4%B8%AD%E5%9B%BD\))


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
